### PR TITLE
All code for the docker plugin for juju workload processes

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -77,7 +77,20 @@ func launchArgs(p process.Process) ([]string, error) {
 	}
 
 	for _, p := range p.Ports {
-		args = append(args, "-p", fmt.Sprintf("%d:%d", p.External, p.Internal))
+		if p.External.To > 0 {
+			args = append(args, "-p",
+				fmt.Sprintf("%d-%d:%d-%d/%s",
+					p.External.From,
+					p.External.To,
+					p.Internal.From,
+					p.Internal.To,
+					p.Protocol,
+				),
+			)
+
+		} else {
+			args = append(args, "-p", fmt.Sprintf("%d:%d/%s", p.External.From, p.Internal.From, p.Protocol))
+		}
 	}
 
 	for _, v := range p.Volumes {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,0 +1,166 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package docker exposes an API to convert Jujuisms to dockerisms.
+package docker
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/juju/deputy"
+	"gopkg.in/juju/charm.v5/process"
+)
+
+// Launch runs a new docker container with the given process data.
+func Launch(p process.Process) (ProcDetails, error) {
+	args, err := launchArgs(p)
+	if err != nil {
+		return ProcDetails{}, err
+	}
+	d := deputy.Deputy{
+		Errors: deputy.FromStderr,
+	}
+	cmd := exec.Command("docker", args...)
+	out := &bytes.Buffer{}
+	cmd.Stdout = out
+	if err := d.Run(cmd); err != nil {
+		return ProcDetails{}, err
+	}
+	id := string(bytes.TrimSpace(out.Bytes()))
+	status, err := inspect(id)
+	if err != nil {
+		return ProcDetails{}, fmt.Errorf("can't get status for container %q: %s", id, err)
+	}
+	return ProcDetails{ID: status.Name, ProcStatus: ProcStatus{Status: status.brief()}}, nil
+}
+
+// Status returns the ProcStatus for the docker container with the given id.
+func Status(id string) (ProcStatus, error) {
+	status, err := inspect(id)
+	if err != nil {
+		return ProcStatus{}, err
+	}
+	return ProcStatus{Status: status.brief()}, nil
+}
+
+// Destroy stops and removes the docker container with the given id.
+func Destroy(id string) error {
+	d := deputy.Deputy{
+		Errors: deputy.FromStderr,
+	}
+	cmd := exec.Command("docker", "stop", id)
+	if err := d.Run(cmd); err != nil {
+		return fmt.Errorf("error while stopping container %q: %s", err)
+	}
+
+	cmd = exec.Command("docker", "rm", id)
+	if err := d.Run(cmd); err != nil {
+		return fmt.Errorf("error while removing container %q: %s", err)
+	}
+	return nil
+}
+
+// launchArgs converts the Process struct into arguments for the docker run
+// command.
+func launchArgs(p process.Process) ([]string, error) {
+	if err := p.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid proc-info: %s", err)
+	}
+
+	args := []string{"run", "--detach", "--name", p.Name}
+	for k, v := range p.EnvVars {
+		args = append(args, "-e", k+"="+v)
+	}
+
+	for _, p := range p.Ports {
+		args = append(args, "-p", fmt.Sprintf("%d:%d", p.External, p.Internal))
+	}
+
+	for _, v := range p.Volumes {
+		args = append(args, "-v", fmt.Sprintf("%s:%s:%s", v.ExternalMount, v.InternalMount, v.Mode))
+	}
+
+	// Image and Command must come after all options.
+	args = append(args, p.Image)
+	if len(p.Command) > 0 {
+		args = append(args, p.Command...)
+	}
+	return args, nil
+}
+
+// status is the struct that contains the schema returned by docker's inspect command
+type status struct {
+	State struct {
+		Running    bool
+		Paused     bool
+		Restarting bool
+		OOMKilled  bool
+		Dead       bool
+		Pid        int
+		ExitCode   int
+		Error      string
+	}
+	Name string
+}
+
+// brief returns a short summary for the status.
+func (s *status) brief() string {
+	switch {
+	case s.State.Running:
+		return "Running"
+	case s.State.OOMKilled:
+		return "OOMKilled"
+	case s.State.Dead:
+		return "Dead"
+	case s.State.Restarting:
+		return "Restarting"
+	case s.State.Paused:
+		return "Paused"
+	}
+	return "Unknown"
+}
+
+// inspect calls docker inspect and returns the unmarshaled json response.
+func inspect(id string) (status, error) {
+	cmd := exec.Command("docker", "inspect", id)
+	out := &bytes.Buffer{}
+	cmd.Stdout = out
+	d := deputy.Deputy{
+		Errors: deputy.FromStderr,
+	}
+	if err := d.Run(cmd); err != nil {
+		return status{}, err
+	}
+	var st []status
+	if err := json.Unmarshal(out.Bytes(), &st); err != nil {
+		return status{}, fmt.Errorf("can't decode response from docker inspect %s: %s", id, err)
+	}
+	if len(st) == 0 {
+		return status{}, errors.New("no status returned from docker inspect " + id)
+	}
+	if len(st) > 1 {
+		return status{}, errors.New("multiple status values returned from docker inspect " + id)
+	}
+	return st[0], nil
+}
+
+// These two structs are copied from juju/process/plugin
+
+// ProcDetails represents information about a process launched by a plugin.
+type ProcDetails struct {
+	// ID is a unique string identifying the process to the plugin.
+	ID string `json:"id"`
+	// ProcStatus is the status of the process after launch.
+	ProcStatus
+}
+
+// ProcStatus represents the data returned from the Status call.
+type ProcStatus struct {
+	// Status represents the human-readable string returned by the plugin for
+	// the process.
+	Status string `json:"status"`
+}

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -11,7 +11,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v5/process"
+	"gopkg.in/juju/charm.v5"
 )
 
 type suite struct{}
@@ -24,16 +24,16 @@ func (suite) TestLaunchArgs(c *gc.C) {
 	expected := []string{
 		"run",
 		"--detach",
-		"--name", fakeProc.Name,
+		"--name", "juju-name",
 		"-e", "foo=bar",
 		"-e", "baz=bat",
-		"-p", "8080-8090:80-90/tcp",
+		"-p", "8080:80/tcp",
 		"-p", "8022:22/tcp",
 		"-v", "/foo:/bar:ro",
 		"-v", "/baz:/bat:rw",
-		fakeProc.Image,
+		"docker/whalesay",
+		"cowsay", "boo!",
 	}
-	expected = append(expected, fakeProc.Command...)
 	c.Check(args, gc.DeepEquals, expected)
 }
 
@@ -104,32 +104,32 @@ func (suite) TestBrief(c *gc.C) {
 	}
 }
 
-var fakeProc = process.Process{
+var fakeProc = charm.Process{
 	Name:        "juju-name",
 	Description: "desc",
 	Type:        "docker",
 	TypeOptions: map[string]string{"foo": "bar"},
-	Command:     []string{"cowsay", "boo!"},
-	Image:       "docker/whalesay",
-	Ports: []process.Port{
-		process.Port{
-			External: process.PortRange{8080, 8090},
-			Internal: process.PortRange{80, 90},
-			Protocol: "tcp",
+	// TODO(natefinch): update this when Command becomes a slice
+	Command: "cowsay boo!",
+	Image:   "docker/whalesay",
+	// TODO(natefinch): update this when we use portranges
+	Ports: []charm.ProcessPort{
+		charm.ProcessPort{
+			External: 8080,
+			Internal: 80,
 		},
-		process.Port{
-			External: process.PortRange{From: 8022},
-			Internal: process.PortRange{From: 22},
-			Protocol: "tcp",
+		charm.ProcessPort{
+			External: 8022,
+			Internal: 22,
 		},
 	},
-	Volumes: []process.Volume{
-		process.Volume{
+	Volumes: []charm.ProcessVolume{
+		charm.ProcessVolume{
 			ExternalMount: "/foo",
 			InternalMount: "/bar",
 			Mode:          "ro",
 		},
-		process.Volume{
+		charm.ProcessVolume{
 			ExternalMount: "/baz",
 			InternalMount: "/bat",
 			Mode:          "rw",

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -4,6 +4,11 @@
 package docker
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v5/process"
@@ -14,53 +19,375 @@ type suite struct{}
 var _ = gc.Suite(&suite{})
 
 func (suite) TestLaunchArgs(c *gc.C) {
-	p := process.Process{
-		Name:        "juju-name",
-		Description: "desc",
-		Type:        "docker",
-		TypeOptions: map[string]string{"foo": "bar"},
-		Command:     []string{"cowsay", "boo!"},
-		Image:       "docker/whalesay",
-		Ports: []process.Port{
-			process.Port{
-				External: process.PortRange{8080, 8090},
-				Internal: process.PortRange{80, 90},
-				Protocol: "tcp",
-			},
-			process.Port{
-				External: process.PortRange{From: 8022},
-				Internal: process.PortRange{From: 22},
-				Protocol: "tcp",
-			},
-		},
-		Volumes: []process.Volume{
-			process.Volume{
-				ExternalMount: "/foo",
-				InternalMount: "/bar",
-				Mode:          "ro",
-			},
-			process.Volume{
-				ExternalMount: "/baz",
-				InternalMount: "/bat",
-				Mode:          "rw",
-			},
-		},
-		EnvVars: map[string]string{"foo": "bar", "baz": "bat"},
-	}
-	args, err := launchArgs(p)
+	args, err := launchArgs(fakeProc)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []string{
 		"run",
 		"--detach",
-		"--name", p.Name,
+		"--name", fakeProc.Name,
 		"-e", "foo=bar",
 		"-e", "baz=bat",
 		"-p", "8080-8090:80-90/tcp",
 		"-p", "8022:22/tcp",
 		"-v", "/foo:/bar:ro",
 		"-v", "/baz:/bat:rw",
-		p.Image,
+		fakeProc.Image,
 	}
-	expected = append(expected, p.Command...)
+	expected = append(expected, fakeProc.Command...)
 	c.Check(args, gc.DeepEquals, expected)
+}
+
+func (suite) TestStatusFromInspectNone(c *gc.C) {
+	b := []byte("not json")
+	_, err := statusFromInspect("id", b)
+	c.Assert(err, gc.ErrorMatches, "can't decode response from docker inspect id.*")
+}
+
+func (suite) TestStatusFromInspectEmpty(c *gc.C) {
+	b := []byte(`[]`)
+	_, err := statusFromInspect("id", b)
+	c.Assert(err, gc.ErrorMatches, "no status returned from docker inspect id")
+}
+
+func (suite) TestStatusFromInspectMultiple(c *gc.C) {
+	b := []byte(`[{"Name":"foo"},{"Name":"bar"}]`)
+	_, err := statusFromInspect("id", b)
+	c.Assert(err, gc.ErrorMatches, "multiple status values returned from docker inspect id")
+}
+
+func (suite) TestStatusFromInspect(c *gc.C) {
+	s, err := statusFromInspect("id", []byte(fakeInspectOutput))
+	c.Assert(err, jc.ErrorIsNil)
+	expected := status{
+		State: state{
+			Running: true,
+			Pid:     11820,
+		},
+		Name: "/sad_perlman",
+	}
+	c.Assert(s, gc.Equals, expected)
+}
+
+func (suite) TestBrief(c *gc.C) {
+	type test struct {
+		in  status
+		out string
+	}
+	tests := []test{
+		{
+			in:  status{State: state{Running: true}},
+			out: "Running",
+		},
+		{
+			in:  status{State: state{OOMKilled: true}},
+			out: "OOMKilled",
+		},
+		{
+			in:  status{State: state{Dead: true}},
+			out: "Dead",
+		},
+		{
+			in:  status{State: state{Restarting: true}},
+			out: "Restarting",
+		},
+		{
+			in:  status{State: state{Paused: true}},
+			out: "Paused",
+		},
+		{
+			in:  status{},
+			out: "Unknown",
+		},
+	}
+	for _, t := range tests {
+		c.Check(t.out, gc.Equals, t.in.brief())
+	}
+}
+
+var fakeProc = process.Process{
+	Name:        "juju-name",
+	Description: "desc",
+	Type:        "docker",
+	TypeOptions: map[string]string{"foo": "bar"},
+	Command:     []string{"cowsay", "boo!"},
+	Image:       "docker/whalesay",
+	Ports: []process.Port{
+		process.Port{
+			External: process.PortRange{8080, 8090},
+			Internal: process.PortRange{80, 90},
+			Protocol: "tcp",
+		},
+		process.Port{
+			External: process.PortRange{From: 8022},
+			Internal: process.PortRange{From: 22},
+			Protocol: "tcp",
+		},
+	},
+	Volumes: []process.Volume{
+		process.Volume{
+			ExternalMount: "/foo",
+			InternalMount: "/bar",
+			Mode:          "ro",
+		},
+		process.Volume{
+			ExternalMount: "/baz",
+			InternalMount: "/bat",
+			Mode:          "rw",
+		},
+	},
+	EnvVars: map[string]string{"foo": "bar", "baz": "bat"},
+}
+
+const fakeInspectOutput = `
+[
+{
+    "Id": "b508c7d5c2722b7ac4f105fedf835789fb705f71feb6e264f542dc33cdc41232",
+    "Created": "2015-06-25T11:05:53.694518797Z",
+    "Path": "sleep",
+    "Args": [
+        "30"
+    ],
+    "State": {
+        "Running": true,
+        "Paused": false,
+        "Restarting": false,
+        "OOMKilled": false,
+        "Dead": false,
+        "Pid": 11820,
+        "ExitCode": 0,
+        "Error": "",
+        "StartedAt": "2015-06-25T11:05:53.8401024Z",
+        "FinishedAt": "0001-01-01T00:00:00Z"
+    },
+    "Image": "fb434121fc77c965f255cbb848927f577bbdbd9325bdc1d7f1b33f99936b9abb",
+    "NetworkSettings": {
+        "Bridge": "",
+        "EndpointID": "9915c7299be4f77c18f3999ef422b79996ea8c5796e2befd1442d67e5cefb50d",
+        "Gateway": "172.17.42.1",
+        "GlobalIPv6Address": "",
+        "GlobalIPv6PrefixLen": 0,
+        "HairpinMode": false,
+        "IPAddress": "172.17.0.2",
+        "IPPrefixLen": 16,
+        "IPv6Gateway": "",
+        "LinkLocalIPv6Address": "",
+        "LinkLocalIPv6PrefixLen": 0,
+        "MacAddress": "02:42:ac:11:00:02",
+        "NetworkID": "3346546be8f76006e44000b007da48e576e788ba1d3e3cd275545837d4d7c80a",
+        "PortMapping": null,
+        "Ports": {},
+        "SandboxKey": "/var/run/docker/netns/b508c7d5c272",
+        "SecondaryIPAddresses": null,
+        "SecondaryIPv6Addresses": null
+    },
+    "ResolvConfPath": "/var/lib/docker/containers/b508c7d5c2722b7ac4f105fedf835789fb705f71feb6e264f542dc33cdc41232/resolv.conf",
+    "HostnamePath": "/var/lib/docker/containers/b508c7d5c2722b7ac4f105fedf835789fb705f71feb6e264f542dc33cdc41232/hostname",
+    "HostsPath": "/var/lib/docker/containers/b508c7d5c2722b7ac4f105fedf835789fb705f71feb6e264f542dc33cdc41232/hosts",
+    "LogPath": "/var/lib/docker/containers/b508c7d5c2722b7ac4f105fedf835789fb705f71feb6e264f542dc33cdc41232/b508c7d5c2722b7ac4f105fedf835789fb705f71feb6e264f542dc33cdc41232-json.log",
+    "Name": "/sad_perlman",
+    "RestartCount": 0,
+    "Driver": "aufs",
+    "ExecDriver": "native-0.2",
+    "MountLabel": "",
+    "ProcessLabel": "",
+    "Volumes": {},
+    "VolumesRW": {},
+    "AppArmorProfile": "",
+    "ExecIDs": null,
+    "HostConfig": {
+        "Binds": null,
+        "ContainerIDFile": "",
+        "LxcConf": [],
+        "Memory": 0,
+        "MemorySwap": 0,
+        "CpuShares": 0,
+        "CpuPeriod": 0,
+        "CpusetCpus": "",
+        "CpusetMems": "",
+        "CpuQuota": 0,
+        "BlkioWeight": 0,
+        "OomKillDisable": false,
+        "Privileged": false,
+        "PortBindings": {},
+        "Links": null,
+        "PublishAllPorts": false,
+        "Dns": null,
+        "DnsSearch": null,
+        "ExtraHosts": null,
+        "VolumesFrom": null,
+        "Devices": [],
+        "NetworkMode": "bridge",
+        "IpcMode": "",
+        "PidMode": "",
+        "UTSMode": "",
+        "CapAdd": null,
+        "CapDrop": null,
+        "RestartPolicy": {
+            "Name": "no",
+            "MaximumRetryCount": 0
+        },
+        "SecurityOpt": null,
+        "ReadonlyRootfs": false,
+        "Ulimits": null,
+        "LogConfig": {
+            "Type": "json-file",
+            "Config": {}
+        },
+        "CgroupParent": ""
+    },
+    "Config": {
+        "Hostname": "b508c7d5c272",
+        "Domainname": "",
+        "User": "",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "PortSpecs": null,
+        "ExposedPorts": null,
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": [
+            "PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Cmd": [
+            "sleep",
+            "30"
+        ],
+        "Image": "docker/whalesay",
+        "Volumes": null,
+        "VolumeDriver": "",
+        "WorkingDir": "/cowsay",
+        "Entrypoint": null,
+        "NetworkDisabled": false,
+        "MacAddress": "",
+        "OnBuild": null,
+        "Labels": {}
+    }
+}
+]
+`
+
+func (suite) TestLaunch(c *gc.C) {
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+	pd, err := Launch(fakeProc)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := ProcDetails{ID: "/sad_perlman", ProcStatus: ProcStatus{"Running"}}
+	c.Assert(pd, gc.Equals, expected)
+}
+
+func (suite) TestStatus(c *gc.C) {
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+	ps, err := Status("someid")
+	c.Assert(err, jc.ErrorIsNil)
+	expected := ProcStatus{"Running"}
+	c.Assert(ps, gc.Equals, expected)
+}
+
+func (suite) TestDestroy(c *gc.C) {
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+	err := Destroy("someid")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func fakeExecCommand(name string, args ...string) *exec.Cmd {
+	args = append([]string{"-test.run=TestExecHelper", "--", name}, args...)
+	cmd := exec.Command(os.Args[0], args...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+func fakeExecCommandError(name string, args ...string) *exec.Cmd {
+	cmd := fakeExecCommand(name, args...)
+	cmd.Env = append(cmd.Env, "GO_HELPER_PROCESS_ERROR=1")
+	return cmd
+}
+
+func TestExecHelper(*testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	args := getTestArgs()
+	shouldErr := os.Getenv("GO_HELPER_PROCESS_ERROR") == "1"
+	if shouldErr {
+		defer os.Exit(1)
+	} else {
+		defer os.Exit(0)
+	}
+	switch args[0] {
+	case "run":
+		doRun(shouldErr)
+	case "inspect":
+		doInspect(shouldErr)
+	case "stop":
+		doStop(shouldErr)
+	case "rm":
+		doRm(shouldErr)
+	}
+}
+
+func doStop(shouldErr bool) {
+	if shouldErr {
+		fmt.Fprintln(os.Stderr, "Error response from daemon: no such id: foo")
+		return
+	}
+	// when docker successfully stops a container, it prints out the container id.
+	fmt.Fprintln(os.Stdout, "somebigid")
+}
+
+func doRm(shouldErr bool) {
+	if shouldErr {
+		fmt.Fprintln(os.Stderr, "Error response from daemon: no such id: foo")
+		return
+	}
+	// when docker successfully removes a container, it prints out the container id.
+	fmt.Fprintln(os.Stdout, "somebigid")
+}
+
+func doRun(shouldErr bool) {
+	if shouldErr {
+		fmt.Fprintf(os.Stderr, `Unable to find image 'foo:latest' locally
+Pulling repository foo
+Error: image library/foo:latest not found
+`)
+		return
+	}
+	fmt.Fprintln(os.Stdout, "somebigid")
+}
+
+func doInspect(shouldErr bool) {
+	if shouldErr {
+		fmt.Fprintln(os.Stderr, "Error: No such image or container: wegwgwg")
+		fmt.Fprintln(os.Stdout, "[]")
+		return
+	}
+	fmt.Fprint(os.Stdout, fakeInspectOutput)
+}
+
+// getTestArgs returns the args being passed to docker, so arg[0] would be the
+// docker command, like "run" or "stop".  This function will exit out of the
+// helper exec if it was not passed at least 3 arguments (e.g. docker stop id),
+// or if the first arg is not "docker".
+func getTestArgs() []string {
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) < 3 {
+		fmt.Fprintf(os.Stderr, "Not enough arguments passed to docker: %#v\n", args)
+		os.Exit(2)
+	}
+	if args[0] != "docker" {
+		fmt.Fprintf(os.Stderr, "Calling %q instead of docker\n", args[0])
+		os.Exit(2)
+	}
+
+	return args[1:]
 }

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -293,6 +293,10 @@ func (suite) TestDestroy(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+// fakeExecCommand replaces the normal exec.Command call to produce executables.
+// It returns a command that calls this test executable, telling it to run our
+// TestExecHelper test.  The original command and arguments are passed as
+// arguments to the testhelper after a "--" argument.
 func fakeExecCommand(name string, args ...string) *exec.Cmd {
 	args = append([]string{"-test.run=TestExecHelper", "--", name}, args...)
 	cmd := exec.Command(os.Args[0], args...)
@@ -306,6 +310,8 @@ func fakeExecCommandError(name string, args ...string) *exec.Cmd {
 	return cmd
 }
 
+// TestExecHelper is a fake test that is just used to do predictable things when
+// we run commands.
 func TestExecHelper(*testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -1,0 +1,43 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package docker
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5/process"
+)
+
+type suite struct{}
+
+var _ = gc.Suite(&suite{})
+
+func (suite) TestLaunchArgs(c *gc.C) {
+	p := process.Process{
+		Name:        "juju-name",
+		Description: "desc",
+		Type:        "docker",
+		TypeOptions: map[string]string{"foo": "bar"},
+		Command:     []string{"cowsay", "boo!"},
+		Image:       "docker/whalesay",
+		Ports: []process.Port{
+			process.Port{
+				External: process.PortRange{8080, 8090},
+				Internal: process.PortRange{80, 88},
+				Protocol: "tcp",
+			},
+		},
+		Volumes: []process.Volume{
+			process.Volume{
+				ExternalMount: "/foo",
+				InternalMount: "/bar",
+				Mode:          "ro",
+			},
+		},
+		EnvVars: map[string]string{"foo": "bar"},
+	}
+	args, err := launchArgs(p)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(args, gc.DeepEquals, []string{"run", "--detach", "--name", p.Name, "-e", "foo=bar"})
+}

--- a/docker/package_test.go
+++ b/docker/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package docker
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"os"
 
 	"github.com/juju/juju-process-docker/docker"
-	"gopkg.in/juju/charm.v5/process"
+	"gopkg.in/juju/charm.v5"
 )
 
 func init() {
@@ -174,7 +174,7 @@ var (
 )
 
 func launch(proc string) int {
-	p := process.Process{}
+	p := charm.Process{}
 	if err := json.Unmarshal([]byte(proc), &p); err != nil {
 		stdout.Printf("can't decode proc-info: %s", err)
 		return 1

--- a/main.go
+++ b/main.go
@@ -1,0 +1,215 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Command juju-process-docker is a plugin for Juju which enables Juju's
+// workload process management to manage Docker containers.
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/juju/juju-process-docker/docker"
+	"gopkg.in/juju/charm.v5/process"
+)
+
+func init() {
+	log.SetFlags(0)
+}
+
+var stdout = log.New(os.Stdout, "", 0)
+
+const (
+	mainUsage = `juju-process-docker is a plugin for Juju which enables Juju's workload process
+management to manage Docker containers.
+
+Usage:
+  juju-process-docker <command> [args]
+
+Commands:
+  help [command]	show this help, or help for a command
+  launch <process>	launch a docker container with the given parameters
+  status <id> 		return status for the process with the given id
+  destroy <id>		stop and clean up the process with the given id
+
+For more details about a command, use help <command>.
+`
+
+	launchUsage = `launch starts a docker container with the given parameters.
+
+Usage:
+  juju-process-docker launch <process>
+
+process is expected to be a json object with the following format:
+
+{
+	"Name": "unique-image-name",
+	"Command": ["command", "to", "run"],
+	"Image": "docker/whalesay",
+	"Ports": [
+		{
+			"External": {
+				"From": 7888,
+				"To" : 7988
+			},
+			"Internal": {
+				"From": 37888,
+				"To": 37988
+			}
+			"Protocol": "tcp"
+			"Endpoint": ""
+		}
+	],
+	"Volumes": [
+		{
+			"ExternalMount": "/foo/bar",
+			"InternalMount": "/baz/bat",
+			"Mode": "ro",
+			"Name": "foobar"
+		}
+	],
+	"EnvVars": {
+		"foo": "bar"
+	}
+}
+
+
+`
+	statusUsage = `status returns information about the given docker container.
+
+Usage:
+  juju-process-docker status <id>
+
+Id is expected to be the id of a docker container running on this machine.
+`
+	destroyUsage = `destroy stops and cleans up after the given docker container.
+
+Usage:
+  juju-process-docker destroy <id>
+
+Id is expected to be the id of a docker container running on this machine.
+`
+)
+
+type command struct {
+	name  string
+	usage string
+	fn    func(string) int
+}
+
+var cmds = map[string]*command{
+	"launch": &command{
+		usage: launchUsage,
+		fn:    launch,
+	},
+	"destroy": &command{
+		usage: destroyUsage,
+		fn:    destroy,
+	},
+	"status": &command{
+		usage: statusUsage,
+		fn:    status,
+	},
+}
+
+func main() {
+	os.Exit(Main(os.Args[1:]))
+}
+
+func Main(args []string) int {
+	if code, exit := maybeHelp(args); exit {
+		return code
+	}
+
+	return run(args)
+}
+
+func maybeHelp(args []string) (code int, exit bool) {
+	if len(args) == 0 {
+		log.Print(mainUsage)
+		return 0, true
+	}
+
+	if args[0] == "help" {
+		if len(args) == 1 {
+			log.Print(mainUsage)
+			return 0, true
+		}
+		for name, cmd := range cmds {
+			if name == args[1] {
+				log.Print(cmd.usage)
+				return 0, true
+			}
+		}
+		stdout.Printf("unknown command %q", args[1])
+		log.Println()
+		log.Print(mainUsage)
+		return 1, true
+	}
+	return 0, false
+}
+
+func run(args []string) int {
+	for name, cmd := range cmds {
+		if args[0] == name {
+			if len(args) != 2 {
+				stdout.Printf("wrong number of arguments for cmd %q", name)
+				log.Println()
+				log.Print(cmd.usage)
+				return 1
+			}
+			// valid command.
+			return cmd.fn(args[1])
+		}
+	}
+	stdout.Printf("unknown command %q", args[0])
+	log.Println()
+	log.Print(mainUsage)
+	return 1
+}
+
+func launch(proc string) int {
+	p := process.Process{}
+	if err := json.Unmarshal([]byte(proc), &p); err != nil {
+		stdout.Printf("can't decode proc-info: %s", err)
+		return 1
+	}
+	details, err := docker.Launch(p)
+	if err != nil {
+		stdout.Print(err)
+		return 1
+	}
+
+	b, err := json.Marshal(details)
+	if err != nil {
+		stdout.Print(err)
+		return 1
+	}
+	stdout.Print(string(b))
+	return 0
+}
+
+func status(id string) int {
+	status, err := docker.Status(id)
+	if err != nil {
+		stdout.Print(err)
+		return 1
+	}
+	b, err := json.Marshal(status)
+	if err != nil {
+		stdout.Print(err)
+		return 1
+	}
+	stdout.Print(string(b))
+	return 0
+}
+
+func destroy(id string) int {
+	err := docker.Destroy(id)
+	if err != nil {
+		stdout.Print(err)
+		return 1
+	}
+	return 0
+}

--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ Commands:
 For more details about a command, use help <command>.
 `
 
+	// TODO(natefinch): fix this when Command becomes a []string.
+	// TODO(natefinch): fix this when we start using portranges.
 	launchUsage = `launch starts a docker container with the given parameters.
 
 Usage:
@@ -45,19 +47,12 @@ process is expected to be a json object with the following format:
 
 {
 	"Name": "unique-container-name",
-	"Command": ["command", "to", "run"],
+	"Command": "command to run",
 	"Image": "docker/whalesay",
 	"Ports": [
 		{
-			"External": {
-				"From": 7888,
-				"To" : 7988
-			},
-			"Internal": {
-				"From": 37888,
-				"To": 37988
-			},
-			"Protocol": "tcp",
+			"External": 7888,
+			"Internal": 37888,
 			"Endpoint": ""
 		}
 	],

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ Usage:
 process is expected to be a json object with the following format:
 
 {
-	"Name": "unique-image-name",
+	"Name": "unique-container-name",
 	"Command": ["command", "to", "run"],
 	"Image": "docker/whalesay",
 	"Ports": [
@@ -56,8 +56,8 @@ process is expected to be a json object with the following format:
 			"Internal": {
 				"From": 37888,
 				"To": 37988
-			}
-			"Protocol": "tcp"
+			},
+			"Protocol": "tcp",
 			"Endpoint": ""
 		}
 	],
@@ -73,22 +73,20 @@ process is expected to be a json object with the following format:
 		"foo": "bar"
 	}
 }
-
-
 `
-	statusUsage = `status returns information about the given docker container.
+	statusUsage = `status returns information about the docker container with the given id.
 
 Usage:
   juju-process-docker status <id>
 
-Id is expected to be the id of a docker container running on this machine.
+Id is expected to be the id or name of a docker container running on this machine.
 `
-	destroyUsage = `destroy stops and cleans up after the given docker container.
+	destroyUsage = `destroy stops and cleans up after the docker container with the given id.
 
 Usage:
   juju-process-docker destroy <id>
 
-Id is expected to be the id of a docker container running on this machine.
+Id is expected to be the id or name of a docker container running on this machine.
 `
 )
 
@@ -169,13 +167,19 @@ func run(args []string) int {
 	return 1
 }
 
+var (
+	dockerLaunch  = docker.Launch
+	dockerStatus  = docker.Status
+	dockerDestroy = docker.Destroy
+)
+
 func launch(proc string) int {
 	p := process.Process{}
 	if err := json.Unmarshal([]byte(proc), &p); err != nil {
 		stdout.Printf("can't decode proc-info: %s", err)
 		return 1
 	}
-	details, err := docker.Launch(p)
+	details, err := dockerLaunch(p)
 	if err != nil {
 		stdout.Print(err)
 		return 1
@@ -191,7 +195,7 @@ func launch(proc string) int {
 }
 
 func status(id string) int {
-	status, err := docker.Status(id)
+	status, err := dockerStatus(id)
 	if err != nil {
 		stdout.Print(err)
 		return 1
@@ -206,7 +210,7 @@ func status(id string) int {
 }
 
 func destroy(id string) int {
-	err := docker.Destroy(id)
+	err := dockerDestroy(id)
 	if err != nil {
 		stdout.Print(err)
 		return 1

--- a/main_test.go
+++ b/main_test.go
@@ -5,9 +5,12 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"log"
 
+	"github.com/juju/juju-process-docker/docker"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5/process"
 )
 
 type suite struct {
@@ -235,5 +238,164 @@ func makeFn(f *fakeCmds, name string) func(string) int {
 		f.name = name
 		f.arg = arg
 		return f.code
+	}
+}
+
+const fakeProcJson = `{
+	"Name": "unique",
+	"Command": ["command", "to", "run"],
+	"Image": "docker/whalesay",
+	"Ports": [
+		{
+			"External": {
+				"From": 7888,
+				"To" : 7988
+			},
+			"Internal": {
+				"From": 37888,
+				"To": 37988
+			},
+			"Protocol": "tcp",
+			"Endpoint": ""
+		}
+	],
+	"Volumes": [
+		{
+			"ExternalMount": "/foo/bar",
+			"InternalMount": "/baz/bat",
+			"Mode": "ro",
+			"Name": "foobar"
+		}
+	],
+	"EnvVars": {
+		"foo": "bar"
+	}
+}
+`
+
+func (s *suite) TestLaunch(c *gc.C) {
+	details := docker.ProcDetails{
+		ID:         "unique",
+		ProcStatus: docker.ProcStatus{Status: "Running"},
+	}
+	out := `{"id":"unique","status":"Running"}
+`
+	type test struct {
+		desc    string
+		proc    string
+		err     error
+		details docker.ProcDetails
+		code    int
+		stdout  string
+	}
+	tests := []test{
+		{
+			desc:    "Default good case.",
+			proc:    fakeProcJson,
+			details: details,
+			stdout:  out,
+		},
+		{
+			desc:   "Bad JSON for process.",
+			proc:   "badjson",
+			code:   1,
+			stdout: "can't decode proc-info:.*\n",
+		},
+		{
+			desc:   "Launch returns error.",
+			proc:   fakeProcJson,
+			err:    errors.New("foooo"),
+			code:   1,
+			stdout: "foooo\n",
+		},
+	}
+
+	for i, t := range tests {
+		c.Logf("%d. %s", i, t.desc)
+		dockerLaunch = func(process.Process) (docker.ProcDetails, error) {
+			return t.details, t.err
+		}
+		code := launch(t.proc)
+		c.Check(code, gc.Equals, t.code)
+		if code == 0 {
+			c.Check(s.stdout.String(), gc.Equals, t.stdout)
+		} else {
+			c.Check(s.stdout.String(), gc.Matches, t.stdout)
+		}
+		s.stdout.Reset()
+	}
+}
+
+func (s *suite) TestStatus(c *gc.C) {
+	type test struct {
+		desc   string
+		err    error
+		status docker.ProcStatus
+		code   int
+		stdout string
+	}
+	tests := []test{
+		{
+			desc:   "Default good case.",
+			status: docker.ProcStatus{Status: "Running"},
+			stdout: `{"status":"Running"}` + "\n",
+		},
+		{
+			desc:   "Docker status error.",
+			code:   1,
+			err:    errors.New("foooo"),
+			stdout: "foooo\n",
+		},
+	}
+
+	for i, t := range tests {
+		c.Logf("%d. %s", i, t.desc)
+		dockerStatus = func(string) (docker.ProcStatus, error) {
+			return t.status, t.err
+		}
+		code := status("foo")
+		c.Check(code, gc.Equals, t.code)
+		if code == 0 {
+			c.Check(s.stdout.String(), gc.Equals, t.stdout)
+		} else {
+			c.Check(s.stdout.String(), gc.Matches, t.stdout)
+		}
+		s.stdout.Reset()
+
+	}
+}
+
+func (s *suite) TestDestroy(c *gc.C) {
+	type test struct {
+		desc   string
+		err    error
+		code   int
+		stdout string
+	}
+	tests := []test{
+		{
+			desc: "Default good case.",
+		},
+		{
+			desc:   "Docker status error.",
+			code:   1,
+			err:    errors.New("foooo"),
+			stdout: "foooo\n",
+		},
+	}
+
+	for i, t := range tests {
+		c.Logf("%d. %s", i, t.desc)
+		dockerDestroy = func(string) error {
+			return t.err
+		}
+		code := destroy("foo")
+		c.Check(code, gc.Equals, t.code)
+		if code == 0 {
+			c.Check(s.stdout.String(), gc.Equals, t.stdout)
+		} else {
+			c.Check(s.stdout.String(), gc.Matches, t.stdout)
+		}
+		s.stdout.Reset()
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/juju/juju-process-docker/docker"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/juju/charm.v5/process"
+	"gopkg.in/juju/charm.v5"
 )
 
 type suite struct {
@@ -241,21 +241,16 @@ func makeFn(f *fakeCmds, name string) func(string) int {
 	}
 }
 
+// TODO(natefinch): update this when we make command into a slice.
+// TODO(natefinch): update this when we start using portranges
 const fakeProcJson = `{
 	"Name": "unique",
-	"Command": ["command", "to", "run"],
+	"Command": "command to run",
 	"Image": "docker/whalesay",
 	"Ports": [
 		{
-			"External": {
-				"From": 7888,
-				"To" : 7988
-			},
-			"Internal": {
-				"From": 37888,
-				"To": 37988
-			},
-			"Protocol": "tcp",
+			"External": 7888,
+			"Internal": 37888,
 			"Endpoint": ""
 		}
 	],
@@ -296,7 +291,7 @@ func (s *suite) TestLaunch(c *gc.C) {
 			stdout:  out,
 		},
 		{
-			desc:   "Bad JSON for process.",
+			desc:   "Bad JSON for charm.",
 			proc:   "badjson",
 			code:   1,
 			stdout: "can't decode proc-info:.*\n",
@@ -312,7 +307,7 @@ func (s *suite) TestLaunch(c *gc.C) {
 
 	for i, t := range tests {
 		c.Logf("%d. %s", i, t.desc)
-		dockerLaunch = func(process.Process) (docker.ProcDetails, error) {
+		dockerLaunch = func(charm.Process) (docker.ProcDetails, error) {
 			return t.details, t.err
 		}
 		code := launch(t.proc)

--- a/package_test.go
+++ b/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This executable will be the plugin that juju runs to interface with docker.  It also serves as an example of how other plugins can be made.  Note that the package main for this executable can be completely reused with a different implementation package with only a couple trivial changes.
