### PR TITLE
support loading repository before launch

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,13 @@ process is expected to be a json object with the following format:
 	"EnvVars": {
 		"foo": "bar"
 	}
+	"TypeOptions": {
+		"RepoFile": "/home/foo/repository-to-load.tar"
+	}
 }
+
+If RepoFile is non-empty, the given repository tar file will be loaded before
+attempting to launch the docker image.
 `
 	statusUsage = `status returns information about the docker container with the given id.
 


### PR DESCRIPTION
Support for "RepoFile" in type-options which should specify a repository file (.tar) for docker to load.  If it exists, it'll be loaded during launch, before we call docker run.

(Review request: http://reviews.vapour.ws/r/2288/)
