### PR TITLE
Compatibility fixes.

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -38,7 +38,12 @@ func Launch(p charm.Process) (ProcDetails, error) {
 	if err != nil {
 		return ProcDetails{}, fmt.Errorf("can't get status for container %q: %s", id, err)
 	}
-	return ProcDetails{ID: status.Name, Status: ProcStatus{Label: status.brief()}}, nil
+	return ProcDetails{
+		ID: status.Name,
+		Status: ProcStatus{
+			State: status.brief(),
+		},
+	}, nil
 }
 
 // Status returns the ProcStatus for the docker container with the given id.
@@ -47,7 +52,9 @@ func Status(id string) (ProcStatus, error) {
 	if err != nil {
 		return ProcStatus{}, err
 	}
-	return ProcStatus{Label: status.brief()}, nil
+	return ProcStatus{
+		State: status.brief(),
+	}, nil
 }
 
 // Destroy stops and removes the docker container with the given id.
@@ -172,7 +179,7 @@ type ProcDetails struct {
 
 // ProcStatus represents the data returned from the Status call.
 type ProcStatus struct {
-	// Label represents the human-readable string returned by the plugin for
+	// State represents the human-readable string returned by the plugin for
 	// the process.
-	Label string `json:"label"`
+	State string `json:"state"`
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -38,8 +38,12 @@ func Launch(p charm.Process) (ProcDetails, error) {
 	if err != nil {
 		return ProcDetails{}, fmt.Errorf("can't get status for container %q: %s", id, err)
 	}
+	name := status.Name
+	if strings.HasPrefix(name, "/") {
+		name = name[1:]
+	}
 	return ProcDetails{
-		ID: status.Name,
+		ID: name,
 		Status: ProcStatus{
 			State: status.brief(),
 		},

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -38,12 +38,8 @@ func Launch(p charm.Process) (ProcDetails, error) {
 	if err != nil {
 		return ProcDetails{}, fmt.Errorf("can't get status for container %q: %s", id, err)
 	}
-	name := status.Name
-	if strings.HasPrefix(name, "/") {
-		name = name[1:]
-	}
 	return ProcDetails{
-		ID: name,
+		ID: strings.TrimPrefix(status.Name, "/"),
 		Status: ProcStatus{
 			State: status.brief(),
 		},

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -276,7 +276,7 @@ func (suite) TestLaunch(c *gc.C) {
 	expected := ProcDetails{
 		ID: "/sad_perlman",
 		Status: ProcStatus{
-			Label: "Running",
+			State: "Running",
 		},
 	}
 	c.Assert(pd, gc.Equals, expected)

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -274,7 +274,7 @@ func (suite) TestLaunch(c *gc.C) {
 	pd, err := Launch(fakeProc)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := ProcDetails{
-		ID: "/sad_perlman",
+		ID: "sad_perlman",
 		Status: ProcStatus{
 			State: "Running",
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -272,10 +272,10 @@ func (s *suite) TestLaunch(c *gc.C) {
 	details := docker.ProcDetails{
 		ID: "unique",
 		Status: docker.ProcStatus{
-			Label: "Running",
+			State: "Running",
 		},
 	}
-	out := `{"id":"unique","status":{"label":"Running"}}
+	out := `{"id":"unique","status":{"state":"Running"}}
 `
 	type test struct {
 		desc    string
@@ -335,9 +335,9 @@ func (s *suite) TestStatus(c *gc.C) {
 		{
 			desc: "Default good case.",
 			status: docker.ProcStatus{
-				Label: "Running",
+				State: "Running",
 			},
-			stdout: `{"label":"Running"}` + "\n",
+			stdout: `{"state":"Running"}` + "\n",
 		},
 		{
 			desc:   "Docker status error.",


### PR DESCRIPTION
This patch fixes two compatibility issues with expectations for Juju workload process plugins:
- rename the proc details status field from Label to State
- strip any leading slash from the proc ID

(Review request: http://reviews.vapour.ws/r/2300/)
